### PR TITLE
Fix route

### DIFF
--- a/app/views/instructor_students/index.html.erb
+++ b/app/views/instructor_students/index.html.erb
@@ -4,7 +4,7 @@
 <%= form_tag("/instructors/#{@instructor.id}/students", method: :get) do %>
   <%= label_tag 'min_age', "Specify minimum age filter for students" %>
   <%= number_field_tag 'min_age', params[:min_age] %>
-  <%= submit_tag "Only return students at or over the given age" %>
+  <%= submit_tag "Filter" %>
 <% end %>
 
 <% @students.each do |student| %>

--- a/app/views/instructors/index.html.erb
+++ b/app/views/instructors/index.html.erb
@@ -4,6 +4,7 @@
   <p><%= instructor %>Name: <%= instructor.name %>, Created at: <%= instructor.created_at %>
     <%= button_to "View #{instructor.name}", "/instructors/#{instructor.id}", method: :get %>
     <%= button_to "Edit #{instructor.name}", "/instructors/#{instructor.id}/edit", method: :get %>
+    <%= button_to "Delete #{instructor.name}", "/instructors/#{instructor.id}", method: :delete %>
   </p>
   <% end %>
 

--- a/app/views/resorts/show.html.erb
+++ b/app/views/resorts/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @resort.name %></h1>
 <%= button_to "Edit #{@resort.name}", "/resorts/#{@resort.id}/edit", method: :get %>
-<%= link_to "Passholders for this Resort", "/resorts/#{@resort.id}/pass_holders" %>
+<%= link_to "Passholders for this Resort", "/resorts/#{@resort.id}/resort_pass_holders" %>
 <p>Number of Passholders: <%= @pass_holders_count%></p>
 <p>ID Number: <%= @resort.id%></p>
 <p>City: <%= @resort.city %></p>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -11,4 +11,5 @@
 
   <p><%= button_to "View #{student.name}", "/students/#{student.id}", method: :get %>
   <%= button_to "Edit #{student.name}", "/students/#{student.id}/edit", method: :get %></p>
+  <%= button_to "Delete #{student.name}", "/students/#{student.id}", method: :delete %></p>
 <% end %>

--- a/spec/features/instructors/index_spec.rb
+++ b/spec/features/instructors/index_spec.rb
@@ -32,4 +32,14 @@ RSpec.describe 'Instructors index' do
     expect(current_path).to eq("/instructors/#{instructor.id}/edit")
   end
 
+  it 'deletes a listed instructor' do
+    instructor = Instructor.create!(name: "Olga", subject: "skiing", teaches_children: false, years_experience: 5)
+    visit '/instructors'
+
+    click_button("Delete #{instructor.name}")
+    expect(current_path).to eq("/instructors")
+
+    expect(page).to_not have_content("Olga")
+  end
+
 end

--- a/spec/features/instructors/students/index_spec.rb
+++ b/spec/features/instructors/students/index_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Instructor's students index" do
     visit "/instructors/#{hans.id}/students"
 
     fill_in(:min_age, with: 18)
-    click_button("Only return students at or over the given age")
+    click_button("Filter")
     
     expect(current_path).to eq("/instructors/#{hans.id}/students")
     expect(page).to have_content(gretchen.name)

--- a/spec/features/resorts/pass_holders/index_spec.rb
+++ b/spec/features/resorts/pass_holders/index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Resorts pass holder index' do
   end
 
   it 'shows all of the names for pass_holders at a given resort' do
-    visit "/resorts/#{@breck.id}/pass_holders"
+    visit "/resorts/#{@breck.id}/resort_pass_holders"
 
     expect(page).to have_content(@jerry.name)
     expect(page).to have_content(@kevin.name)
@@ -20,7 +20,7 @@ RSpec.describe 'Resorts pass holder index' do
   end
 
   it 'has a link to sort all the passholders in alphabetical order' do
-    visit "/resorts/#{@breck.id}/pass_holders"
+    visit "/resorts/#{@breck.id}/resort_pass_holders"
 
     click_link('Sort Passholders Alphabetically')
 

--- a/spec/features/resorts/show_spec.rb
+++ b/spec/features/resorts/show_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe 'the resorts show page' do
 
     click_on "Passholders for this Resort"
 
-    expect(current_path).to eq("/resorts/#{@breck.id}/pass_holders")
-    expect(current_path).to_not eq("/resorts/#{@copper.id}/pass_holders")
-    expect(current_path).to_not eq("/resorts/#{@seven_springs.id}/pass_holders")
+    expect(current_path).to eq("/resorts/#{@breck.id}/resort_pass_holders")
+    expect(current_path).to_not eq("/resorts/#{@copper.id}/resort_pass_holders")
+    expect(current_path).to_not eq("/resorts/#{@seven_springs.id}/resort_pass_holders")
   end
 
   it 'has a can link to edit the resort information' do

--- a/spec/features/students/index_spec.rb
+++ b/spec/features/students/index_spec.rb
@@ -44,4 +44,17 @@ RSpec.describe "Students index" do
     expect(current_path).to eq("/students/#{gretchen.id}/edit")
   end
 
+  it 'deletes a student from the index' do
+    hans = Instructor.create!(name: "Hans", subject: "skiing", teaches_children: true, years_experience: 30)
+    gretchen = hans.students.create!(name: 'Gretchen', age: 20, subject: "cross-country skiing", returning_student: true, level:"advanced")
+    tristan = hans.students.create!(name: 'Tristan', age: 14, subject: "snowboarding", returning_student: false, level:"advanced")
+    bob = hans.students.create!(name: 'Bob', age: 21, subject: "skiing", returning_student: false, level:"advanced")
+
+    visit "/students"
+    click_button "Delete Gretchen"
+
+    expect(current_path).to eq("/students")
+    expect(page).to_not have_content("Gretchen")
+  end
+
 end


### PR DESCRIPTION
When I deleted a route we thought was a duplicate (pass_holders) I broke a few things. Here's a fix, where all mentions of pass_holders have been changed to the convention resort_pass_holders.